### PR TITLE
Rename chzn- prefix to chosen-

### DIFF
--- a/delsort.js
+++ b/delsort.js
@@ -194,7 +194,7 @@
             // Initialize the special chosen.js select box
             // (some code stolen from http://stackoverflow.com/a/27445788)
             $( "#delsort select" ).chosen();
-            $( "#delsort .chzn-container" ).css( "text-align", "left" );
+            $( "#delsort .chosen-container" ).css( "text-align", "left" );
 
             // Add the button that triggers sorting
             $( "#delsort" ).append( $( "<div>" )


### PR DESCRIPTION
chzn- prefix was renamed to chosen- back in 2013 (https://github.com/harvesthq/chosen/pull/1412).  Items appear the same without this line, although have `text-align` as `start`.